### PR TITLE
Fix localization popup disappearing on mobile

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -241,8 +241,8 @@ function createWindow(title, content, initialWidth = 600, initialHeight = 400, o
     if (isMobileView()) {
         const allWindows = document.querySelectorAll('.window');
         allWindows.forEach((window) => {
-            // Skip the main window (the one with class .main-window)
-            if (!window.classList.contains('main-window') && window.id !== 'exit-popup') {
+            // Skip the main window, the exit popup and the localization popup
+            if (!window.classList.contains('main-window') && window.id !== 'exit-popup' && window.id !== 'localization-popup') {
                 window.remove();
             }
         });

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -296,8 +296,8 @@ function createWindow(
         const allWindows = document.querySelectorAll('.window');
 
         allWindows.forEach((window) => {
-            // Skip the main window (the one with class .main-window)
-            if (!window.classList.contains('main-window') && window.id !== 'exit-popup') {
+            // Skip the main window, the exit popup and the localization popup
+            if (!window.classList.contains('main-window') && window.id !== 'exit-popup' && window.id !== 'localization-popup') {
                 window.remove();
             }
         });


### PR DESCRIPTION
## Summary
- keep localization popup element when clearing windows on mobile

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847a454b670832aa84d53c4a7ab53e1